### PR TITLE
[FIX] Hard-clips should not advance read_pos

### DIFF
--- a/include/basics.h
+++ b/include/basics.h
@@ -92,19 +92,22 @@ void advance_in_cigar(unsigned & cigar_pos,
 
         if ((cigar[cigar_pos]).operation == 'M')
         {
+            // Matches/mismatches advance both the read and the reference position
             read_pos += (cigar[cigar_pos]).count;
             ref_pos  += (cigar[cigar_pos]).count;
         }
-        else if ((cigar[cigar_pos]).operation == 'I' ||
-                 (cigar[cigar_pos]).operation == 'S' ||
-                 (cigar[cigar_pos]).operation == 'H')
+        else if ((cigar[cigar_pos]).operation == 'I' || (cigar[cigar_pos]).operation == 'S')
         {
+            // Insertions and soft-clips advance only the read position
             read_pos += (cigar[cigar_pos]).count;
         }
-        else // D
+        else if ((cigar[cigar_pos]).operation == 'D')
         {
+            // Deletions advance only the reference position
             ref_pos += (cigar[cigar_pos]).count;
         }
+        // else hard-clips ('H') advance neither the read nor the reference position
+
         ++cigar_pos;
     }
 }


### PR DESCRIPTION
The CIGAR operation 'H' (meaning that the sequence was hard-clipped) should advance neither the read nor the reference position since the clipped sequence has been removed from the read sequence. Previously the 'H' operation was incorrectly advancing in the read position but this PR fixes that.