### PR TITLE
Check first if SVLEN=- exists.

### DIFF
--- a/include/variant.h
+++ b/include/variant.h
@@ -271,11 +271,14 @@ inline bool refine_variant(seqan::BamAlignmentRecord const & record, Variant & v
             variant.ref_pos_end = ref_pos + variant.sv_length;
 
         // refine info
+        std::regex svlen_neg_re("SVLEN=-[0-9]*");
         std::regex svlen_re("SVLEN=[0-9]*");
         std::regex end_re("END=[0-9]*");
         std::regex seq_re("SEQ=[A-Za-z]*");
 
-        if (std::regex_search(variant.info, svlen_re))
+        if (std::regex_search(variant.info, svlen_neg_re))
+            variant.info = std::regex_replace(variant.info, svlen_neg_re, std::string("SVLEN=-" + std::to_string(variant.sv_length)));
+        else if (std::regex_search(variant.info, svlen_re))
             variant.info = std::regex_replace(variant.info, svlen_re, std::string("SVLEN=" + std::to_string(variant.sv_length)));
         else
             variant.info.append(std::string(";SVLEN=" + std::to_string(variant.sv_length)));


### PR DESCRIPTION
Currently, the regex for SVLEN will not replace a negative number and just appends. You end up with something like "SVLEN=99-100", where "SVLEN=-100" was the original, and it *should* be "SVLEN=-99" afterwards.

This pull request changes it such that it first performs a regex search for the presence of the negative, and if it doesn't find it, then does it without the negative.