### PR TITLE
Add threads and output prefix to option constructor.

### DIFF
--- a/include/sviper/config.h
+++ b/include/sviper/config.h
@@ -23,13 +23,18 @@ struct CmdOptions
     std::string reference_file_name{};
     std::string log_file_name{};
 
-    CmdOptions(std::string long_, std::string short_, std::string candidate_, std::string ref_) :
-        threads(std::thread::hardware_concurrency()),
+    CmdOptions(unsigned threads_,
+               std::string long_,
+               std::string short_,
+               std::string candidate_,
+               std::string ref_,
+               std::string output_prefix_) :
+        threads(threads_),
         long_read_file_name(long_),
         short_read_file_name(short_),
         candidate_file_name(candidate_),
-        output_prefix(candidate_ + "_polished"),
-        reference_file_name(ref_) {}
+        reference_file_name(ref_),
+        output_prefix(output_prefix_) {}
 
     CmdOptions() = default;
     CmdOptions(const CmdOptions&) = default;

--- a/include/sviper/config.h
+++ b/include/sviper/config.h
@@ -10,7 +10,7 @@ struct CmdOptions
     bool verbose{false};
     bool veryVerbose{false};
     bool output_polished_bam{false};
-    unsigned threads{0};
+    unsigned threads{std::thread::hardware_concurrency()};
     int flanking_region{400}; // size of flanking region for breakpoints
     int mean_coverage_of_short_reads{36}; // original coverage
     double mean_insert_size_of_short_reads{280.054}; // original coverage


### PR DESCRIPTION
Currently, other tools using SViper as a library cannot easily change the threads. This allows threads to be set on construction along with specifying the output prefix.