### PR TITLE
Add command to print option values to log file.

### DIFF
--- a/include/sviper/io.h
+++ b/include/sviper/io.h
@@ -102,4 +102,18 @@ bool write_vcf(std::vector<Variant> & variants, std::vector<std::string> & vcf_h
     }
     return true;
 }
+
+void print_log_header(CmdOptions const & options, std::ofstream & log_file)
+{
+    log_file << "Long read file: " << options.long_read_file_name << std::endl
+             << "Short read file: " << options.short_read_file_name << std::endl
+             << "VCF file: " << options.candidate_file_name << std::endl
+             << "Reference file: " << options.reference_file_name << std::endl
+             << "Threads set: " << std::to_string(options.threads) << std::endl
+             << "Flanking region: " << std::to_string(options.flanking_region) << std::endl
+             << "Short read mean coverage: " << std::to_string(options.mean_coverage_of_short_reads) << std::endl
+             << "Insert length mean, std dev: " << std::to_string(options.mean_insert_size_of_short_reads) << ", "
+                                                << std::to_string(options.stdev_insert_size_of_short_reads) << std::endl
+             << "Short read length: " << std::to_string(options.length_of_short_reads) << std::endl;
+}
 } // namespace sviper

--- a/src/sviper.cpp
+++ b/src/sviper.cpp
@@ -18,6 +18,9 @@ int main(int argc, char const ** argv)
         !open_file_success(info.short_read_bai, (info.cmd_options.short_read_file_name + ".bai").c_str()) ||
         !open_file_success(info.log_file, (info.cmd_options.output_prefix + ".log").c_str()))
         return 1;
+
+    // Print all input options to log file. Useful for debugging when using SViper as a library and passing in options manually.
+    print_log_header(info.cmd_options, info.log_file);
     // -------------------------------------------------------------------------
     // Read variants into container // TODO:: use seqan vcf parser instead (needs to be extended)
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Prints options to the log file so that the user knows later on which parameters were set to which values. Especially useful if read lengths/insert lengths are automatically calculated and passed on to SViper.