### PR TITLE
Move writing custom filter messages to a separate function so other t…

### DIFF
--- a/include/sviper/io.h
+++ b/include/sviper/io.h
@@ -30,6 +30,21 @@ bool read_vcf(std::vector<Variant> & variants, std::vector<std::string> & vcf_he
     return true;
 }
 
+void write_custom_filters(std::ofstream & output_vcf)
+{
+    output_vcf << "##FILTER=<ID=FAIL0,Description=\"The fasta index has no entry for the given "
+               << "reference name of the variant.\">" << std::endl;
+    output_vcf << "##FILTER=<ID=FAIL1,Description=\"No long reads in variant region.\">" << std::endl;
+    output_vcf << "##FILTER=<ID=FAIL2,Description=\"No long reads support the variant.\">" << std::endl;
+    output_vcf << "##FILTER=<ID=FAIL3,Description=\"The long read regions do not fit.\">" << std::endl;
+    output_vcf << "##FILTER=<ID=FAIL4,Description=\"Not enough short reads.\">" << std::endl;
+    output_vcf << "##FILTER=<ID=FAIL5,Description=\"The variant was polished away.\">" << std::endl;
+    output_vcf << "##FILTER=<ID=FAIL6,Description=\"The variant reference name does not exist in the " <<
+                  "short read BAM file.\">" << std::endl;
+    output_vcf << "##FILTER=<ID=FAIL7,Description=\"The variant reference name does not exist in the " <<
+                  "long read BAM file.\">" << std::endl;
+}
+
 bool write_vcf(std::vector<Variant> & variants, std::vector<std::string> & vcf_header, input_output_information & info)
 {
     std::ofstream output_vcf{};          // The polished variant as output
@@ -64,17 +79,7 @@ bool write_vcf(std::vector<Variant> & variants, std::vector<std::string> & vcf_h
             }
 
             // write out custom filters
-            output_vcf << "##FILTER=<ID=FAIL0,Description=\"The fasta index has no entry for the given "
-                       << "reference name of the variant.\">" << std::endl;
-            output_vcf << "##FILTER=<ID=FAIL1,Description=\"No long reads in variant region.\">" << std::endl;
-            output_vcf << "##FILTER=<ID=FAIL2,Description=\"No long reads support the variant.\">" << std::endl;
-            output_vcf << "##FILTER=<ID=FAIL3,Description=\"The long read regions do not fit.\">" << std::endl;
-            output_vcf << "##FILTER=<ID=FAIL4,Description=\"Not enough short reads.\">" << std::endl;
-            output_vcf << "##FILTER=<ID=FAIL5,Description=\"The variant was polished away.\">" << std::endl;
-            output_vcf << "##FILTER=<ID=FAIL6,Description=\"The variant reference name does not exist in the " <<
-                          "short read BAM file.\">" << std::endl;
-            output_vcf << "##FILTER=<ID=FAIL7,Description=\"The variant reference name does not exist in the " <<
-                          "long read BAM file.\">" << std::endl;
+            write_custom_filters(output_vcf);
         }
 
         output_vcf << vcf_header[hl] << std::endl;


### PR DESCRIPTION
…ools can access this.

Currently other tools can't automatically add SViper headers when integrating SViper because if they don't use SViper's write_vcf function.

This way they can get SViper's filter info into an ofstream and pass it to their own output.